### PR TITLE
Allow to manually trigger the autobump

### DIFF
--- a/.github/workflows/autobump.yaml
+++ b/.github/workflows/autobump.yaml
@@ -3,6 +3,7 @@ name: Autobump
 on:
   schedule:
     - cron: '30 2 * * 1-5'
+  workflow_dispatch: {} # allow manual trigger
 
 jobs:
   autobump-go:


### PR DESCRIPTION
Follow up to #9 

/kind cleanup

I hope this should fix the following:

```shell
$ gh workflow run Autobump
could not create workflow dispatch event: HTTP 422: Workflow does not have 'workflow_dispatch' trigger (https://api.github.com/repos/cardil/deviate/actions/workflows/146696845/dispatches)
```