### PR TITLE
Allow a .github/deviate.yaml as default configuration

### DIFF
--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -15,7 +15,15 @@ func addFlags(root *cobra.Command, opts *cli.Options) {
 	if err != nil {
 		panic(err)
 	}
+
+	// Default to .deviate.yaml or .github/deviate.yaml in the root
 	config := path.Join(wd, ".deviate.yaml")
+	if _, err := os.Stat(config); os.IsNotExist(err) {
+		githubConfig := path.Join(wd, ".github", "deviate.yaml")
+		if _, errStatGithub := os.Stat(githubConfig); errStatGithub == nil {
+			config = githubConfig
+		}
+	}
 	fl.StringVar(&opts.ConfigPath, "config", config,
 		metadata.Name+" configuration file")
 }


### PR DESCRIPTION
UI improvement so that you don't need to specify a config path when running from a github workflow. `.github/` seems to be the natural location for the configuration of many tools that are triggered by GitHub workflows.