### PR TITLE
fix: Ensure that remote "downstream" is available

### DIFF
--- a/pkg/git/push_prelease.go
+++ b/pkg/git/push_prelease.go
@@ -15,6 +15,11 @@ func (r Repository) Push(remote git.Remote, refname plumbing.ReferenceName) erro
 	specs := []config.RefSpec{
 		refSpecForReferenceName(refname),
 	}
+
+	if err := r.ensureRemote(remote); err != nil {
+		return err
+	}
+
 	auth, err := authentication(remote)
 	if err != nil {
 		return errors.Wrap(err, ErrLocalOperationFailed)


### PR DESCRIPTION
If you don't have locally a remote named "downstream" then the push for syncing tags doesn't work.
SOlution: Ensure that "downstream" exists, much like for "upstream"