### PR TITLE
feat: Refactor CI message generation to use templates

### DIFF
--- a/pkg/sync/create_pr.go
+++ b/pkg/sync/create_pr.go
@@ -14,7 +14,7 @@ func (o Operation) createSyncReleaseNextPR() error {
 	branches := o.Config.Branches
 	return o.createPR(
 		o.triggerCIMessage(),
-		fmt.Sprintf(o.Config.Messages.TriggerCIBody, branches.ReleaseNext, branches.Main),
+		o.triggerCIBody(),
 		branches.ReleaseNext,
 		branches.SynchCI+branches.ReleaseNext,
 	)


### PR DESCRIPTION
Updated the triggerCI and createSyncReleasePR functions to utilize text templates for generating CI messages and bodies. This change improves message formatting and error handling when parsing templates. The previous string formatting has been replaced with template execution, enhancing maintainability and readability.