### PR TITLE
chore: Polished CLI output a bit

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -17,9 +17,10 @@ type App struct{}
 
 func (a App) Command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     metadata.Name,
-		Short:   metadata.Description,
-		Version: metadata.Version,
+		Use:          metadata.Name,
+		Short:        metadata.Description,
+		Version:      metadata.Version,
+		SilenceUsage: true,
 	}
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)

--- a/pkg/sync/create_pr.go
+++ b/pkg/sync/create_pr.go
@@ -100,8 +100,8 @@ func (c createPR) open() error {
 	}
 	cl := github.NewClient(args...)
 	cl.ProjectDir = c.Project.Path
-	buff, err := cl.Execute(c.Context)
-	defer c.Println("Github client:", buff)
+	_, err = cl.Execute(c.Context)
+
 	return errors.Wrap(err, ErrSyncFailed)
 }
 


### PR DESCRIPTION
- Added `SilenceUsage: true` to the command configuration to suppress usage messages.
- Simplified error handling in the GitHub client by removing unnecessary buffer variable.