### PR TITLE
:gift: Relative paths for config

### DIFF
--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"os"
-	"path"
-
 	"github.com/openshift-knative/deviate/pkg/cli"
 	"github.com/openshift-knative/deviate/pkg/metadata"
 	"github.com/spf13/cobra"
@@ -11,11 +8,6 @@ import (
 
 func addFlags(root *cobra.Command, opts *cli.Options) {
 	fl := root.PersistentFlags()
-	wd, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
-	config := path.Join(wd, ".deviate.yaml")
-	fl.StringVar(&opts.ConfigPath, "config", config,
+	fl.StringVar(&opts.ConfigPath, "config", ".deviate.yaml",
 		metadata.Name+" configuration file")
 }

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"path"
 
 	"github.com/openshift-knative/deviate/pkg/cli"
@@ -29,9 +30,17 @@ func (s sync) run(cmd *cobra.Command, args []string) error {
 
 func (s sync) project(args []string) func() config.Project {
 	return func() config.Project {
+		configPath := s.ConfigPath
+		wd, err := os.Getwd()
+		if err != nil {
+			wd = "/"
+		}
+		if !path.IsAbs(configPath) {
+			configPath = path.Join(wd, configPath)
+		}
 		project := config.Project{
-			ConfigPath: s.ConfigPath,
-			Path:       path.Dir(s.ConfigPath),
+			ConfigPath: configPath,
+			Path:       wd,
 		}
 		if len(args) > 0 {
 			project.Path = args[0]


### PR DESCRIPTION
This allows to use relative paths easily.

```shell
$ go run github.com/openshift-knative/deviate@latest --config .github/deviate.yaml
```
Related to #37 

/cc @rhuss 