### PR TITLE
Fix autobump: use bot token to trigger CI checks

### DIFF
--- a/.github/workflows/autobump.yaml
+++ b/.github/workflows/autobump.yaml
@@ -28,4 +28,4 @@ jobs:
         --branch autobump/go
         --dep github.com/openshift-knative/hack
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}


### PR DESCRIPTION
GITHUB_TOKEN doesn't trigger workflows on created PRs due to GitHub's security policy. Switch to SERVERLESS_QE_ROBOT bot account token to ensure Mage and Lints workflows run on autobump PRs.